### PR TITLE
Split forward links and back links as a other row.

### DIFF
--- a/src/ui/ConnectedLinksView.tsx
+++ b/src/ui/ConnectedLinksView.tsx
@@ -8,6 +8,8 @@ interface ConnectedLinksViewProps {
   getPreview: (fileEntity: FileEntity) => Promise<string>;
   boxWidth: string;
   boxHeight: string;
+  title: string;
+  className: string;
 }
 
 export default class ConnectedLinksView extends React.Component<ConnectedLinksViewProps> {
@@ -18,7 +20,7 @@ export default class ConnectedLinksView extends React.Component<ConnectedLinksVi
   render(): JSX.Element {
     if (this.props.fileEntities.length > 0) {
       return (
-        <div className="twohop-links-section">
+        <div className={"twohop-links-section " + this.props.className}>
           <div
             className={"twohop-links-box twohop-links-connected-links-header"}
             style={{
@@ -26,7 +28,7 @@ export default class ConnectedLinksView extends React.Component<ConnectedLinksVi
               height: this.props.boxHeight,
             }}
           >
-            Links
+            {this.props.title}
           </div>
           {this.props.fileEntities.map((it) => {
             return (

--- a/src/ui/TwohopLinksRootView.tsx
+++ b/src/ui/TwohopLinksRootView.tsx
@@ -9,8 +9,9 @@ import { TagLinks } from "../model/TagLinks";
 import TagLinksListView from "./TagLinksListView";
 
 interface TwohopLinksRootViewProps {
-  connectedLinks: FileEntity[];
+  forwardConnectedLinks: FileEntity[];
   newLinks: FileEntity[];
+  backwardConnectedLinks: FileEntity[];
   resolvedTwoHopLinks: TwohopLink[];
   unresolvedTwoHopLinks: TwohopLink[];
   tagLinksList: TagLinks[];
@@ -29,11 +30,22 @@ export default class TwohopLinksRootView extends React.Component<TwohopLinksRoot
     return (
       <div>
         <ConnectedLinksView
-          fileEntities={this.props.connectedLinks}
+          fileEntities={this.props.forwardConnectedLinks}
           onClick={this.props.onClick}
           getPreview={this.props.getPreview}
           boxWidth={this.props.boxWidth}
           boxHeight={this.props.boxHeight}
+          title={"Links"}
+          className={"twohop-links-forward-links"}
+        />
+        <ConnectedLinksView
+          fileEntities={this.props.backwardConnectedLinks}
+          onClick={this.props.onClick}
+          getPreview={this.props.getPreview}
+          boxWidth={this.props.boxWidth}
+          boxHeight={this.props.boxHeight}
+          title={"Back Links"}
+          className={"twohop-links-back-links"}
         />
         <TwohopLinksView
           twoHopLinks={this.props.unresolvedTwoHopLinks}

--- a/styles.css
+++ b/styles.css
@@ -33,8 +33,11 @@
 }
 
 /* connected links */
-.twohop-links-connected-links-header {
+.twohop-links-forward-links .twohop-links-connected-links-header {
   background-color: darkkhaki;
+}
+.twohop-links-back-links .twohop-links-connected-links-header {
+  background-color: salmon;
 }
 
 /* two hop links */


### PR DESCRIPTION
- Do not show entries that listed on forward link in the back link list.
- Do not show entries that listed on forward link in the 2hop link list.
- Provide the new css class `.twohop-links-forward-links` and `.twohop-links-back-links` for the row.

Close #16 