### PR TITLE
Fix layout issue in editor mode

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -152,7 +152,7 @@ export default class TwohopLinksPlugin extends Plugin {
   private getContainerElements(markdownView: MarkdownView): Element[] {
     if (this.settings.putOnTop) {
       const elements = markdownView.containerEl.querySelectorAll(
-        ".markdown-source-view .CodeMirror-scroll, .markdown-preview-view, .markdown-source-view .cm-contentContainer"
+        ".markdown-source-view .CodeMirror-scroll, .markdown-preview-view, .markdown-source-view .cm-sizer"
       );
       console.debug(`getContainerElements: ${elements.length}`);
 
@@ -176,7 +176,7 @@ export default class TwohopLinksPlugin extends Plugin {
       return containers;
     } else {
       const elements = markdownView.containerEl.querySelectorAll(
-        ".markdown-source-view .CodeMirror-lines, .markdown-preview-view, .markdown-source-view .cm-contentContainer"
+        ".markdown-source-view .CodeMirror-lines, .markdown-preview-view, .markdown-source-view .cm-sizer"
       );
 
       const containers: Element[] = [];


### PR DESCRIPTION
I have fixed the layout issue reported #43 .

In v1.0.3, `cm-contentContainer` has `display: flex;` so that it is a sibling element of `cm-contentContainer`.

But, the next element of `cm-contentContainer` has `min-height`, so it has a large space.

<img width="653" alt="image" src="https://user-images.githubusercontent.com/6875/206891039-e4c5ae24-9441-438d-8a9b-80af22fd669b.png">
